### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 [systems-mcp](https://github.com/lethain/systems-mcp) is an MCP server for interacting with
 the [`lethain:systems`](https://github.com/lethain/systems/) library for systems modeling.
 
+<a href="https://glama.ai/mcp/servers/@lethain/systems-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@lethain/systems-mcp/badge" alt="Systems MCP server" />
+</a>
+
 It provides two tools:
 
 * `run_systems_model` runs the `systems` specification of a systems model.
@@ -75,5 +79,3 @@ It should work similarly on other platforms.
 
 5. Close Claude and reopen it.
 6. It should work...
-
-


### PR DESCRIPTION
This PR adds a badge for the [Systems MCP](https://glama.ai/mcp/servers/@lethain/systems-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@lethain/systems-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@lethain/systems-mcp/badge" alt="Systems MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.